### PR TITLE
Fixing a divide-by-zero exception occurring on certain machines

### DIFF
--- a/src/main/java/com/threerings/media/timer/CalibratingTimer.java
+++ b/src/main/java/com/threerings/media/timer/CalibratingTimer.java
@@ -54,7 +54,13 @@ public abstract class CalibratingTimer
     // documentation inherited from interface
     public long getElapsedMicros ()
     {
-        return elapsed() / _microDivider;
+        // Some machines will have set _microDivider to 0
+        if (_microDivider == 0) {
+            // Just convert our millisecond value instead
+            return getElapsedMillis() * 1000;
+        } else {
+            return elapsed() / _microDivider;
+        }
     }
 
     // documentation inherited from interface


### PR DESCRIPTION
Avoiding a divide-by-zero exception in CalibratingTimer when Perf.highResFrequency() returns 0 on certain machines.
